### PR TITLE
ocaml5: update callback3 with caml_ prefix and stub warnings and errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ CARCHIVE=lib$(CARCHIVE_NAME).a
 # Flags for the C compiler.
 CFLAGS:=$(CFLAGS) -Wall $(EVENT_CFLAGS)
 
-OCAMLC=ocamlc
-OCAMLOPT=ocamlopt
+OCAMLC=ocamlc -I +unix
+OCAMLOPT=ocamlopt -I +unix
 OCAMLDEP=ocamldep
 OCAMLMKLIB=ocamlmklib
 OCAMLDOC=ocamldoc

--- a/event_stubs.c
+++ b/event_stubs.c
@@ -136,7 +136,7 @@ static void
 event_cb(int fd, short type, void *arg)
 {
   caml_leave_blocking_section();
-  callback3(*event_cb_closure,
+  caml_callback3(*event_cb_closure,
 	    Val_long((long) arg), Val_int(fd), Val_int(type));
   caml_enter_blocking_section();
 }
@@ -306,7 +306,7 @@ oc_event_base_init(value unit)
   if(event_cb_closure == NULL) {
     event_cb_closure = caml_named_value("event_cb");
     if(event_cb_closure == NULL) {
-      invalid_argument("Callback event_cb not initialized.");
+      caml_invalid_argument("Callback event_cb not initialized.");
     }
   }
 

--- a/unittest.ml
+++ b/unittest.ml
@@ -58,7 +58,7 @@ let test_read_eof () =
   Unix.shutdown s1 Unix.SHUTDOWN_SEND;
 
   (* Setup the event *)
-  Global.set evt s2 [READ] false read_cb;
+  Global.set evt s2 [READ] ~persist:false read_cb;
   add evt None;
   Global.dispatch ();
 
@@ -71,9 +71,9 @@ let call_set () =
     ()
   in
   let e1 = create () in
-  Global.set e1 Unix.stderr [WRITE] false do_nothing;
-  Global.set e1 Unix.stdout [WRITE] false do_nothing;
-  Global.set e1 Unix.stdin [READ] false do_nothing;
+  Global.set e1 Unix.stderr [WRITE] ~persist:false do_nothing;
+  Global.set e1 Unix.stdout [WRITE] ~persist:false do_nothing;
+  Global.set e1 Unix.stdin [READ] ~persist:false do_nothing;
   add e1 (Some 0.1);
   Global.loop ONCE
 


### PR DESCRIPTION
Compatibility with OCaml5

Changes:
1. Makefile: The OCaml lib directory changed in 5.0. Added `-I +unix` flags to `ocamlc` and `ocamlopt` to support finding unix subdirectory and stub warnings
2. Add in caml_ prefix for forward compatibility
3. Update unittest.ml to stub warnings of labelled arguments